### PR TITLE
Calculates area of circle

### DIFF
--- a/circlearea.rb
+++ b/circlearea.rb
@@ -1,0 +1,6 @@
+def area(radius)
+  radius.to_f
+  return 3.1415926535898 * radius ** 2
+end
+
+p area 6


### PR DESCRIPTION
Calculates area of circle, taking the circles radius as its only parameter. The formula is: pi times radius squared or 3.14r^^2 where r is the radius.